### PR TITLE
Initial spectator implementation

### DIFF
--- a/src/frontend/javascripts/game.js
+++ b/src/frontend/javascripts/game.js
@@ -9,6 +9,7 @@ import { EVENTS } from '../../common/events';
 import { OurDisplay, dispOpts } from './display';
 import { loginScreen } from './screens/login';
 import { playScreen } from './screens/play.js'
+import { spectateScreen } from './screens/spectate.js';
 // import { GameMap } from '../../common/map';
 
 const hostname = location.host;
@@ -33,6 +34,7 @@ class Game {
         this.title = " Kaverns & Kubernetes ";
         this.client = new EntityClient(BASE_URL,(event, data) => {this.refresh(event, data);});
         this.messages = [];
+        this.spectatorOnly = false;
 
         const bindEventToScreen = (event) => {
             window.addEventListener(event, function(e) {
@@ -107,8 +109,12 @@ class Game {
 
     mapAvailable(map) {
         this.map = new ExplorerMap(map);
-        this.map.setupFov();
-        this.switchScreen(playScreen);
+        if (this.spectatorOnly) {
+            this.switchScreen(spectateScreen);
+        } else {
+            this.map.setupFov();
+            this.switchScreen(playScreen);
+        }
     }
 
     getMap() {
@@ -169,6 +175,9 @@ class Game {
             properties = this.updateName();
             properties.type = "player";
         }
+        if (properties.role === "spectator") {
+            this.spectatorOnly = true;
+        }
         backendMonitor.setServerURL(`${properties.url}/health`);
         this.client.connectToServer(properties);
     }
@@ -228,6 +237,10 @@ class Game {
         game.statsField.find("#lvl").text(`LVL:${stats.lvl}`);
         game.statsField.find("#gp").text(`GP:${stats.gp}`);
         game.statsField.find("#hunger").text(`${stats.hunger}`);
+    }
+
+    setStats(stats) {
+        game.statsField.html(stats);
     }
 
     setNameField(nameInput, roleInput, caveInput) {
@@ -328,6 +341,10 @@ class Game {
 
     getEntity() {
         return this.client.getEntity();
+    }
+
+    getOtherEntities() {
+        return this.client.getOtherEntities();
     }
 }
 

--- a/src/frontend/javascripts/keys.js
+++ b/src/frontend/javascripts/keys.js
@@ -62,3 +62,15 @@ export const getHandler = function(inputType, inputData) {
     }
     return handler;
 }
+
+export const getSpectatorHandler = function(inputType, inputData) {
+    let handler = null;
+    if (inputType === 'keydown') {
+        if (inputData.keyCode === KEYS.VK_UP) {
+            handler = { func: function() { this.spectatePreviousPlayer() }};
+        } else if (inputData.keyCode === KEYS.VK_DOWN) {
+            handler = { func: function() { this.spectateNextPlayer() }};
+        }
+    }
+    return handler;
+}

--- a/src/frontend/javascripts/screens/index.js
+++ b/src/frontend/javascripts/screens/index.js
@@ -11,6 +11,9 @@ Screens.helpScreen = helpScreen;
 import {playScreen}  from "./play.js"; 
 Screens.playScreen = playScreen;
 
+import {spectateScreen}  from "./spectate.js"; 
+Screens.spectateScreen = spectateScreen;
+
 import {lookScreen}  from "./target.js"; 
 Screens.lookScreen = lookScreen;
 

--- a/src/frontend/javascripts/screens/spectate.js
+++ b/src/frontend/javascripts/screens/spectate.js
@@ -1,0 +1,135 @@
+'use strict';
+
+import { Color } from '../display.js';
+import { game } from '../game.js';
+import { getSpectatorHandler } from '../keys.js';
+import { Glyph } from '../../../common/glyph';
+
+class SpectateScreen {
+    
+    constructor() {
+        this.screenWidth = null;
+        this.screenHeight = null;
+        this.trackedEntityIndex = 0;
+    }
+
+    getTrackedEntity() {
+        return game.getOtherEntities()[this.trackedEntityIndex];
+    }
+
+    enter() {
+        this.screenWidth = game.getScreenWidth();
+        this.screenHeight = game.getScreenHeight();
+    }
+
+    render(display) {
+        this.renderMap(display);
+        this.renderMessages();
+        this.renderStats();
+    }
+
+    renderMap(display) {
+        let map = game.getMap();
+        let topLeft = this.getScreenOffsets(map);
+        for (let x = topLeft.x; x < topLeft.x + this.screenWidth; x++) {
+            for (let y = topLeft.y; y < topLeft.y + this.screenHeight; y++) {
+                let glyph = this.getColouredGlyph(map, x, y, this.getTrackedEntity().getPos().z);
+                display.draw(x - topLeft.x,
+                                y - topLeft.y, 
+                                glyph.getChar(), glyph.getForeground(), glyph.getBackground());
+            }
+        }
+    }
+
+    getScreenOffsets(map) {
+        let topLeftX = Math.max(0, this.getTrackedEntity().getPos().x - Math.round(this.screenWidth / 2));
+        topLeftX = Math.min(topLeftX, Math.max(0, map.getWidth() - this.screenWidth));
+        let topLeftY = Math.max(0, this.getTrackedEntity().getPos().y - Math.round(this.screenHeight / 2));
+        topLeftY = Math.min(topLeftY, Math.max(0, map.getHeight() - this.screenHeight));
+        return {
+            x: topLeftX,
+            y: topLeftY
+        };
+    }
+
+    getColouredGlyph(map, x, y, z) {
+        let glyph = map.getTile(x, y, z);
+        let foreground = Color.fromString('#211');
+        let items = game.getItemsAt(x, y, z);
+        if (items.length > 0) {
+            glyph = items.slice(-1)[0];
+        }
+        if (game.getEntityAt(x, y, z)) {
+            glyph = game.getEntityAt(x, y, z);
+        }
+        let itemColour = Color.fromString(glyph.getForeground());
+        if (glyph.id === this.getTrackedEntity().id) {
+            itemColour = Color.fromString('lightblue');
+        }
+        foreground = Color.interpolate(foreground, itemColour, 1);
+        return new Glyph({'char': glyph.getChar(), 'foreground':Color.toRGB(foreground),'background':glyph.getBackground()});
+    }
+
+    renderMessages() {
+        let messages = game.getMessages();
+        for (let i = 0; i < messages.length; i++) {
+            game.updateMessages(messages[i]);
+        }
+        game.clearMessages();
+    }
+
+    renderStats() {
+        let statsHTML = '<hr>';
+        for (let [i, entity] of game.getOtherEntities().entries()) {
+            if (entity.isAlive()) {
+                let colour = i === this.trackedEntityIndex ? 'lightblue' : entity.getForeground();
+                statsHTML += '<span style="color:' + colour + '">';
+                statsHTML += entity.getName() + ' | ';
+                statsHTML += 'HP: ' + entity.getHitPoints() + ' | ';
+                let pos = entity.getPos();
+                statsHTML += pos.x + ', ' + pos.y + ', ' + pos.z + ' | ';
+                for (let item of entity.getInventory()) {
+                    statsHTML += item.getChar();
+                };
+                statsHTML += '</span><br />';
+            }
+        }
+        game.setStats(statsHTML);
+    }
+
+    handleInput(inputType, inputData) {   
+        let handler = getSpectatorHandler(inputType, inputData);
+        if (handler) {
+            handler.func.call(this,inputData);
+        }
+    }
+
+    spectatePreviousPlayer() {
+        if (game.getOtherEntities().length == 0) {
+            return;
+        }
+
+        do {
+            this.trackedEntityIndex--;
+            if (this.trackedEntityIndex === -1) {
+                this.trackedEntityIndex = game.getOtherEntities().length - 1;
+            }
+        } while (!this.getTrackedEntity().isAlive());
+    }
+
+    spectateNextPlayer() {
+        if (game.getOtherEntities().length == 0) {
+            return;
+        }
+
+        do {
+            this.trackedEntityIndex++;
+            if (this.trackedEntityIndex >= game.getOtherEntities().length) {
+                this.trackedEntityIndex = 0;
+            }
+        } while (!this.getTrackedEntity().isAlive());
+    }
+
+}
+
+export const spectateScreen = new SpectateScreen();

--- a/src/routes/roles.ts
+++ b/src/routes/roles.ts
@@ -13,6 +13,8 @@ for (const key in Players) {
   ROLES.push({type:role, name:Role})
 }
 
+ROLES.push({type: "spectator", name: "Spectator"});
+
 export default function (app: Application): void {
   const router = Router();
   router.get('/', function (req, res, next) { // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/server/cave.ts
+++ b/src/server/cave.ts
@@ -114,7 +114,15 @@ export class Cave {
         return this.map;
     }
 
-    getItems(level: number): CaveItems {
+    getItems(): CaveItems {
+        return Object.keys(this.items)
+            .reduce<CaveItems>((item, key) => {
+                item[key] = this.items[key];
+                return item;
+            }, {});
+    }
+
+    getItemsForRoom(level: number): CaveItems {
         return Object.keys(this.items)
             .filter(key => key.split(',')[2] === `${level})`)
             .reduce<CaveItems>((item, key) => {

--- a/src/server/messaging.ts
+++ b/src/server/messaging.ts
@@ -28,6 +28,11 @@ export class Messaging {
         this.backend.in(this.prefix+String(room)).emit(cmd, data);
     }
 
+    sendToSpectators(cmd: string, data: unknown): void {
+        log.debug(`messaging.sendToSpectators()| ${cmd}`, data);
+        this.backend.in('SPECTATORS').emit(cmd, data);
+    }
+
     sendToAll(cmd: string, data: unknown): void {
         log.debug(`messaging.sendToAll()| ${cmd}`, data);
         this.backend.emit(cmd, data);

--- a/test/cave.test.ts
+++ b/test/cave.test.ts
@@ -117,14 +117,14 @@ describe('cave creation', () => {
 
     it('should have 0 number of items', () => {
         const cave = new Cave(template);
-        const items = cave.getItems(0);
+        const items = cave.getItemsForRoom(0);
         expect(Object.keys(items).length).toBe(0);
     });
 
     it('should have 1 number of items', () => {
         template.itemTypes = { "rock": 1 };
         const cave = new Cave(template);
-        const items = cave.getItems(0);
+        const items = cave.getItemsForRoom(0);
         expect(Object.keys(items).length).toBe(1);
     });
 
@@ -132,7 +132,7 @@ describe('cave creation', () => {
         (template as any).itemTypes0 = { 'rock': 1, 'dagger': 1 };
         (template as any).itemTypes1 = { 'rock': 1, 'dagger': 1 };
         const cave = new Cave(template);
-        const items = cave.getItems(0);
+        const items = cave.getItemsForRoom(0);
         let hasDagger = false;
         let hasRock = false;
         Object.keys(items).forEach(key => {
@@ -152,7 +152,7 @@ describe('cave creation', () => {
     it('should have a one dagger where non-existent types requested', () => {
         template.itemTypes = { 'dagger': 1, 'non-thing': 1 };
         const cave = new Cave(template);
-        const items = cave.getItems(0);
+        const items = cave.getItemsForRoom(0);
         let hasDagger = 0;
         Object.keys(items).forEach(key => {
             items[key].forEach(item => {
@@ -167,7 +167,7 @@ describe('cave creation', () => {
     it('should have two daggers and no rocks', () => {
         (template as any).itemTypes0 = { 'rock': 0, 'dagger': 2, 'non-thing': 1 };
         const cave = new Cave(template);
-        const items = cave.getItems(0);
+        const items = cave.getItemsForRoom(0);
         let hasDagger = 0;
         let hasRock = 0;
         Object.keys(items).forEach(key => {

--- a/test/rest-service.test.ts
+++ b/test/rest-service.test.ts
@@ -37,7 +37,8 @@ describe('basic REST API', () => {
     it('should return roles', (done) => {
         const expected = [
             { type: 'warrior', name: 'Warrior' },
-            { type: 'wizard', name: 'Wizard' }
+            { type: 'wizard', name: 'Wizard' },
+            { type: 'spectator', name: 'Spectator' },
           ];
 
         axios.get(`${addr}/roles`,{

--- a/test/rogue-spectator.test.ts
+++ b/test/rogue-spectator.test.ts
@@ -1,0 +1,297 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { io, Socket } from 'socket.io-client';
+import { ConnectionServer } from '../dist/server/connection-server';
+import { DIRS } from '../dist/common/movement';
+import { EntityState } from '../dist/common/entity';
+import { EVENTS } from '../dist/common/events';
+import { MapState } from '../dist/common/map';
+import { Apple } from '../dist/server/items/apple';
+import { Dagger } from '../dist/server/items/dagger';
+import { ItemState } from '../dist/common/item';
+
+let spectator: Socket;
+let playerOne: Socket;
+let playerTwo: Socket;
+let httpServer: http.Server;
+let httpServerAddr: AddressInfo;
+let app: ConnectionServer;
+let pollForExpectedEventsOnConnect: NodeJS.Timeout;
+
+const defaultMap = {
+    depth: 1,
+    width: 100,
+    height: 100,
+    entrance: { x: 0, y: 0, z: 0 },
+    gateways: 'test_url',
+};
+
+const apple = new Apple();
+const dagger = new Dagger();
+
+const PLAYER_ONE_NAME = 'playerOne';
+const PLAYER_TWO_NAME = 'playerTwo';
+
+beforeEach((done) => {
+    httpServer = http.createServer();
+    httpServerAddr = httpServer.listen().address() as AddressInfo;
+    app = new ConnectionServer(httpServer, defaultMap);
+
+    spectator = io(`http://[${httpServerAddr.address}]:${httpServerAddr.port}`, {
+        transports: ['websocket'],
+        auth: {
+            name: 'spectator',
+            role: 'spectator'
+        }
+    });
+
+    let entitiesReceived = false;
+    let itemsReceived = false;
+
+    spectator.on(EVENTS.entities, () => {
+        entitiesReceived = true;
+    });
+
+    spectator.on(EVENTS.items, () => {
+        itemsReceived = true;
+    });
+
+    pollForExpectedEventsOnConnect = setInterval(() => {
+        if (entitiesReceived && itemsReceived) {
+            clearInterval(pollForExpectedEventsOnConnect);
+            done();
+        }
+    }, 50);
+});
+
+function addPlayerOne() {
+    playerOne = io(`http://[${httpServerAddr.address}]:${httpServerAddr.port}`, {
+        transports: ['websocket'],
+        auth: {
+            name: PLAYER_ONE_NAME,
+            role: 'testcode'
+        }
+    });
+}
+
+function addPlayerTwo() {
+    playerTwo = io(`http://[${httpServerAddr.address}]:${httpServerAddr.port}`, {
+        transports: ['websocket'],
+        auth: {
+            name: PLAYER_TWO_NAME,
+            role: 'testcode'
+        }
+    });
+}
+
+afterEach((done) => {
+    clearInterval(pollForExpectedEventsOnConnect);
+    if (spectator.connected) {
+        spectator.disconnect();
+    }
+    if (playerOne && playerOne.connected) {
+        playerOne.disconnect();
+    }
+    if (playerTwo && playerTwo.connected) {
+        playerTwo.disconnect();
+    }
+    app.stop();
+    httpServer.close();
+    done();
+});
+
+describe('spectators can watch games', () => {
+
+    it('should get pings', (done) => {
+        spectator.on(EVENTS.ping, () => {
+            done();
+        });
+    });
+
+    it('should be able to get the map', (done) => {
+        spectator.on(EVENTS.map, (map: MapState) => {
+            expect(map.depth).toBe(defaultMap.depth);
+            expect(map.width).toBe(defaultMap.width);
+            expect(map.height).toBe(defaultMap.height);
+            expect(map.tiles.length).toBe(defaultMap.depth);
+            expect(map.tiles[0].length).toBe(defaultMap.height);
+            expect(map.tiles[0][0].length).toBe(defaultMap.width);
+            done();
+        });
+
+        spectator.emit(EVENTS.getMap);
+    });
+
+    it('should get notified when an entity moves', (done) => {
+        spectator.on(EVENTS.entities, (entities: EntityState[]) => {
+            entities.forEach(entity => {
+                if (entity.name === PLAYER_ONE_NAME) {
+                    playerOne.emit(EVENTS.move, DIRS.SOUTH);
+                }
+            });
+        });
+
+        spectator.on(EVENTS.position, (payload: EntityState) => {
+            expect(payload.id).toBe(playerOne.id);
+            expect(payload.pos.x).toBe(0);
+            expect(payload.pos.y).toBe(1);
+            expect(payload.pos.z).toBe(0);
+            done();
+        });
+
+        addPlayerOne();
+    });
+
+    it('should get notified that an item is no longer on the map when it is taken', (done) => {
+        app.entityServer.cave.addItem({ x: 0, y: 0, z: 0 }, apple);
+
+        spectator.on(EVENTS.items, (items: { [location: string]: ItemState[] }) => {
+            expect(items).toEqual({});
+            done();
+        });
+
+        addPlayerOne();
+
+        playerOne.on('connect', () => {
+            playerOne.emit(EVENTS.take, apple.getName());
+        });
+    });
+
+    it('should get notified that an entity has an item when one is taken', (done) => {
+        app.entityServer.cave.addItem({ x: 0, y: 0, z: 0 }, apple);
+
+        spectator.on(EVENTS.entities, (entities: EntityState[]) => {
+            entities.forEach(entity => {
+                if (entity.name === PLAYER_ONE_NAME) {
+                    if (entity.inventory.length === 1 && entity.inventory[0].name === apple.getName()) {
+                        done();
+                    }
+                }
+            });
+        });
+
+        addPlayerOne();
+
+        playerOne.on('connect', () => {
+            playerOne.emit(EVENTS.take, apple.getName());
+        });
+    });
+
+    it('should get notified that an entity no longer has an item when one is dropped', (done) => {
+        let playerOneHasBeenSeenWithTheApple = false;
+        app.entityServer.cave.addItem({ x: 0, y: 0, z: 0 }, apple);
+
+        spectator.on(EVENTS.entities, (entities: EntityState[]) => {
+            entities.forEach(entity => {
+                if (entity.name === PLAYER_ONE_NAME) {
+                    if (playerOneHasBeenSeenWithTheApple) {
+                        if (entity.inventory.length === 0) {
+                            done();
+                        }
+                    } else {
+                        if (entity.inventory.length === 1 && entity.inventory[0].name === apple.getName()) {
+                            playerOneHasBeenSeenWithTheApple = true;
+                            playerOne.emit(EVENTS.drop, apple.getName());
+                        } else {
+                            playerOne.emit(EVENTS.take, apple.getName());
+                        }
+                    }
+                }
+            });
+        });
+
+        addPlayerOne();
+    });
+
+    it('should get notified that an item is now on the map when one is dropped by an entity', (done) => {
+        let playerOneHasBeenSeenWithTheApple = false;
+        app.entityServer.cave.addItem({ x: 0, y: 0, z: 0 }, apple);
+
+        spectator.on(EVENTS.entities, (entities: EntityState[]) => {
+            entities.forEach(entity => {
+                if (entity.name === PLAYER_ONE_NAME) {
+                    if (entity.inventory.length === 1 && entity.inventory[0].name === apple.getName()) {
+                        playerOneHasBeenSeenWithTheApple = true;
+                        playerOne.emit(EVENTS.drop, apple.getName());
+                    } else {
+                        playerOne.emit(EVENTS.take, apple.getName());
+                    }
+                }
+            });
+        });
+
+        spectator.on(EVENTS.items, (items: { [location: string]: ItemState[] }) => {
+            if (playerOneHasBeenSeenWithTheApple) {
+                if (items["(0,0,0)"]) {
+                    if (items["(0,0,0)"][0].name === apple.getName()) {
+                        done();
+                    }
+                }
+            }
+        });
+
+        addPlayerOne();
+    });
+
+    it('should get notified when an entity is hit and takes damage', (done) => {
+        let playerOneReadyToBeAttacked = false;
+        app.entityServer.cave.addItem({ x: 0, y: 0, z: 0 }, dagger);
+
+        spectator.on(EVENTS.entities, (entities: EntityState[]) => {
+            entities.forEach(entity => {
+                if (entity.name === PLAYER_ONE_NAME) {
+                    if (!playerOneReadyToBeAttacked) {
+                        // 1) PlayerOne has joined, move south...
+                        playerOne.emit(EVENTS.move, DIRS.SOUTH);
+                    } else if (entity.hp < 0 && !entity.alive) {
+                        // 6) PlayerOne has been killed by PlayerTwo...
+                        done();
+                    }
+                } else if (entity.name === PLAYER_TWO_NAME) {
+                    if (entity.inventory.length === 0) {
+                        // 3) PlayerTwo has joined, take the dagger...
+                        playerTwo.emit(EVENTS.take, dagger.getName());
+                    } else if (entity.inventory.length === 1) {
+                        if (!entity.currentWeapon) {
+                            // 4) PlayerTwo has the dagger, wield it...
+                            playerTwo.emit(EVENTS.wield, dagger.getName());
+                            spectator.emit(EVENTS.getEntities);
+                        } else {
+                            // 5) PlayerTwo is wielding the dagger, attack PlayerOne...
+                            playerTwo.emit(EVENTS.move, DIRS.SOUTH);
+                        }
+                    }
+                }
+            });
+        });
+
+        spectator.on(EVENTS.position, (payload: EntityState) => {
+            if (payload.id === playerOne.id) {
+                // 2) PlayerOne has moved off the entrance, add PlayerTwo...
+                playerOneReadyToBeAttacked = true;
+                addPlayerTwo();
+            }
+        });
+
+        addPlayerOne();
+    });
+
+    it('should get notified when an entity disconnects', (done) => {
+        spectator.on(EVENTS.entities, (entities: EntityState[]) => {
+            entities.forEach(entity => {
+                if (entity.name === PLAYER_ONE_NAME) {
+                    playerOne.disconnect();
+                }
+            });
+        });
+
+        spectator.on(EVENTS.delete, (entity: EntityState) => {
+            if (entity.name === PLAYER_ONE_NAME) {
+                done();
+            }
+        });
+
+        addPlayerOne(); 
+    });
+
+});


### PR DESCRIPTION
This PR adds a way of watching games. 

A new "Spectator" role appears on the login drop down menu.  When used players can see the entire map.  The spectator screen tracks a player (highlighted in light blue).  The up and down arrow keys can be used to track a different player.

New file `test/rogue-spectator.test.ts` ensures a spectator socket gets notified of all significant events that need to be rendered.